### PR TITLE
Fix molecule vagrant

### DIFF
--- a/defaults/main/002-repmgr.yml
+++ b/defaults/main/002-repmgr.yml
@@ -6,7 +6,7 @@ repmgr_password: repmgr
 repmgr_database: repmgr
 repmgr_conninfo: "host={{ ansible_hostname }} user={{ repmgr_user }} dbname={{ repmgr_database }} connect_timeout=2"
 repmgr_data_directory: "{{ postgresql_data_directory }}"
-repmgr_version: "5.1"
+repmgr_version: 5.1
 
 # Optional configuration items
 #
@@ -14,6 +14,8 @@ repmgr_version: "5.1"
 # Repositories
 repmgr_gpg_key_url: https://dl.2ndquadrant.com/gpg-key.asc
 repmgr_apt_repository: "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt {{ ansible_distribution_release }}-2ndquadrant main"
+# Add the following variable in order to install a specific version from 2nd Quadrant repos using apt. See vars/buster.yml
+# repmgr_version_debian: 
 
 # Replication
 repmgr_primary: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
   name: galaxy
+  enabled: false
 lint: |
   set -e
   yamllint .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,13 @@
-ansible>=2.9.5
+ansible>=2.10
+molecule==3.0.8
+molecule-vagrant==0.3
+python-vagrant
 ansible-lint
 yamllint
 docker
 docker-compose
-molecule>=3.0.4
-molecule-vagrant
 netaddr
 dnspython
-python-vagrant
 cryptography
+jsondiff
+pyyaml

--- a/tasks/extensions/repmgr.yml
+++ b/tasks/extensions/repmgr.yml
@@ -10,9 +10,16 @@
     filename: 2ndquadrant-dl-default-release
   when: ansible_pkg_mgr == "apt"
 
+- name: PostgreSQL | Extensions | Use specific version from repo | apt
+  set_fact:
+    repmgr_apt_name: "postgresql-{{ postgresql_version }}-repmgr={{ repmgr_version_debian }}"
+  when: 
+    - ansible_os_family == "Debian"
+    - repmgr_version_debian is defined
+
 - name: PostgreSQL | Extensions | Make sure the postgres repmgr extensions are installed | apt
   apt:
-    name: "postgresql-{{ postgresql_version }}-repmgr"
+    name: "{{ repmgr_apt_name | default ('postgresql-' + postgresql_version|string + '-repmgr' ) }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{ apt_cache_valid_time | default (3600) }}"

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -1,3 +1,4 @@
 ---
 # PostgreSQL vars for Ubuntu Bionic (18.04LTS)
 postgresql_systemctl_path: /bin
+repmgr_version_debian: 5.1.0-2.buster+1

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -1,4 +1,4 @@
 ---
 # PostgreSQL vars for Ubuntu Bionic (18.04LTS)
 postgresql_systemctl_path: /bin
-repmgr_version_debian: 5.1.0-2.buster+1
+repmgr_version_debian: 5.1.0-2.bionic+1

--- a/vars/buster.yml
+++ b/vars/buster.yml
@@ -1,3 +1,4 @@
 ---
 # PostgreSQL vars for Debian Buster (10.x)
 postgresql_systemctl_path: /usr/bin
+repmgr_version_debian: 5.1.0-2.buster+1

--- a/vars/focal.yml
+++ b/vars/focal.yml
@@ -1,3 +1,4 @@
 ---
 # PostgreSQL vars for Ubuntu Focal (20.04LTS)
 postgresql_systemctl_path: /bin
+repmgr_version_debian: 5.1.0-2.buster+1

--- a/vars/focal.yml
+++ b/vars/focal.yml
@@ -1,4 +1,3 @@
 ---
 # PostgreSQL vars for Ubuntu Focal (20.04LTS)
 postgresql_systemctl_path: /bin
-repmgr_version_debian: 5.1.0-2.buster+1


### PR DESCRIPTION
Pin molecule version and ensure repmgr 5.1 gets installed properly instead of latest (which is now 5.2, released on 22 oct. 2020 thus not yet supported)