### PR TITLE
Fix role name in example playbook of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In order to exactly figure out the purpose and valid values for each of these va
   gather_facts: yes
   become: yes
   roles:
-    - name: fidanf.postgresql-ha
+    - name: fidanf.postgresql_ha
       vars:
         # Required configuration items
         repmgr_target_group: pgcluster


### PR DESCRIPTION
This is a tiny one, but it saves the next person some time. The example playbook has a slightly wrong role name (`-` instead of`_`) and testing that example playbook out will fail. Thus the fix.